### PR TITLE
feat: concurrent safe way to RegisterPlugin

### DIFF
--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -266,7 +266,7 @@ func TestRegisterPluginConcurrent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i := 0; i < 10000; i++ {
+			for i := 0; i < 3; i++ {
 				go func(tt test) {
 					if err := RegisterPlugin(tt.args.name, tt.args.pc, tt.args.sv); !assert.Equal(t, tt.wantErr, err) {
 						t.Errorf("RegisterPlugin() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Maps are not safe for concurrent use. Concurrent read (read only) is SAFE ,Concurrent write and/or read is not. it can improve the robustness of  code. Although function `RegisterPlugin`  is  , generally , not use in concurrent  context,   it is  not sure how users use the public function  `RegisterPlugin` .