### PR TITLE
fix: write response header should not break req

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -128,9 +128,12 @@ func (p *Say) Filter(conf interface{}, w http.ResponseWriter, r pkgHTTP.Request)
 }
 ```
 
-We can see that the Filter takes the value of the body set in the configuration as the response body. If we respond directly in the plugin, it will response directly in the APISIX without touching the upstream.
+We can see that the Filter takes the value of the body set in the configuration as the response body. If we call `Write` or `WriteHeader` of the `http.ResponseWriter`
+(respond directly in the plugin), it will response directly in the APISIX without touching the upstream. As we only support setting headers of local response,
+calling `Header` won't take any effects without calling `Write` or `WriteHeader`. (TODO: support setting response header separately)
 
-Here you can read the API documentation provided by the Go Runner SDK: https://pkg.go.dev/github.com/apache/apisix-go-plugin-runner
+For the `pkgHTTP.Request`, you can refer to the API documentation provided by the Go Runner SDK:
+https://pkg.go.dev/github.com/apache/apisix-go-plugin-runner
 
 After building the application (`make build` in the example), we need to set some environment variables at runtime:
 

--- a/internal/http/response.go
+++ b/internal/http/response.go
@@ -45,6 +45,8 @@ func (r *Response) Write(b []byte) (int, error) {
 		r.body = &bytes.Buffer{}
 	}
 
+	// APISIX will convert code 0 to 200, so we don't need to WriteHeader(http.StatusOK)
+	// before writing the data
 	return r.body.Write(b)
 }
 
@@ -64,7 +66,7 @@ func (r *Response) Reset() {
 }
 
 func (r *Response) HasChange() bool {
-	return !(r.body == nil && r.code == 0 && len(r.hdr) == 0)
+	return !(r.body == nil && r.code == 0)
 }
 
 func (r *Response) FetchChanges(id uint32, builder *flatbuffers.Builder) bool {

--- a/internal/plugin/conf.go
+++ b/internal/plugin/conf.go
@@ -101,8 +101,8 @@ func (cc *ConfCache) Set(req *pc.Req) (uint32, error) {
 			conf, err := plugin.ParseConf(v)
 			if err != nil {
 				log.Errorf(
-					"failed to parse configuration for plugin %s, configuration: %s",
-					name, string(v))
+					"failed to parse configuration for plugin %s, configuration: %s, err: %v",
+					name, string(v), err)
 				continue
 			}
 


### PR DESCRIPTION
Although it won't take effect without calling `Write` or `WriteHeader`
for now.

Fix #64.