### PR TITLE
refactor: rename Response to ReqResponse

### DIFF
--- a/internal/http/header.go
+++ b/internal/http/header.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package http
 
 import "net/http"

--- a/internal/http/header.go
+++ b/internal/http/header.go
@@ -1,0 +1,17 @@
+package http
+
+import "net/http"
+
+type Header struct {
+	http.Header
+}
+
+func newHeader() *Header {
+	return &Header{
+		Header: http.Header{},
+	}
+}
+
+func (h *Header) View() http.Header {
+	return h.Header
+}

--- a/internal/http/req-response.go
+++ b/internal/http/req-response.go
@@ -27,20 +27,20 @@ import (
 	flatbuffers "github.com/google/flatbuffers/go"
 )
 
-type Response struct {
+type ReqResponse struct {
 	hdr  http.Header
 	body *bytes.Buffer
 	code int
 }
 
-func (r *Response) Header() http.Header {
+func (r *ReqResponse) Header() http.Header {
 	if r.hdr == nil {
 		r.hdr = http.Header{}
 	}
 	return r.hdr
 }
 
-func (r *Response) Write(b []byte) (int, error) {
+func (r *ReqResponse) Write(b []byte) (int, error) {
 	if r.body == nil {
 		r.body = &bytes.Buffer{}
 	}
@@ -50,7 +50,7 @@ func (r *Response) Write(b []byte) (int, error) {
 	return r.body.Write(b)
 }
 
-func (r *Response) WriteHeader(statusCode int) {
+func (r *ReqResponse) WriteHeader(statusCode int) {
 	if r.code != 0 {
 		// official WriteHeader can't override written status
 		// keep the same behavior
@@ -59,17 +59,17 @@ func (r *Response) WriteHeader(statusCode int) {
 	r.code = statusCode
 }
 
-func (r *Response) Reset() {
+func (r *ReqResponse) Reset() {
 	r.body = nil
 	r.code = 0
 	r.hdr = nil
 }
 
-func (r *Response) HasChange() bool {
+func (r *ReqResponse) HasChange() bool {
 	return !(r.body == nil && r.code == 0)
 }
 
-func (r *Response) FetchChanges(id uint32, builder *flatbuffers.Builder) bool {
+func (r *ReqResponse) FetchChanges(id uint32, builder *flatbuffers.Builder) bool {
 	if !r.HasChange() {
 		return false
 	}
@@ -132,15 +132,15 @@ func (r *Response) FetchChanges(id uint32, builder *flatbuffers.Builder) bool {
 
 var respPool = sync.Pool{
 	New: func() interface{} {
-		return &Response{}
+		return &ReqResponse{}
 	},
 }
 
-func CreateResponse() *Response {
-	return respPool.Get().(*Response)
+func CreateReqResponse() *ReqResponse {
+	return respPool.Get().(*ReqResponse)
 }
 
-func ReuseResponse(r *Response) {
+func ReuseReqResponse(r *ReqResponse) {
 	r.Reset()
 	respPool.Put(r)
 }

--- a/internal/http/req-response.go
+++ b/internal/http/req-response.go
@@ -130,17 +130,17 @@ func (r *ReqResponse) FetchChanges(id uint32, builder *flatbuffers.Builder) bool
 	return true
 }
 
-var respPool = sync.Pool{
+var reqRespPool = sync.Pool{
 	New: func() interface{} {
 		return &ReqResponse{}
 	},
 }
 
 func CreateReqResponse() *ReqResponse {
-	return respPool.Get().(*ReqResponse)
+	return reqRespPool.Get().(*ReqResponse)
 }
 
 func ReuseReqResponse(r *ReqResponse) {
 	r.Reset()
-	respPool.Put(r)
+	reqRespPool.Put(r)
 }

--- a/internal/http/req-response_test.go
+++ b/internal/http/req-response_test.go
@@ -43,8 +43,8 @@ func getStopAction(t *testing.T, b *flatbuffers.Builder) *hrc.Stop {
 }
 
 func TestFetchChanges(t *testing.T) {
-	r := CreateResponse()
-	defer ReuseResponse(r)
+	r := CreateReqResponse()
+	defer ReuseReqResponse(r)
 	r.Write([]byte("hello"))
 	h := r.Header()
 	h.Set("foo", "bar")
@@ -70,13 +70,13 @@ func TestFetchChanges(t *testing.T) {
 }
 
 func TestFetchChangesEmptyResponse(t *testing.T) {
-	r := CreateResponse()
+	r := CreateReqResponse()
 	builder := util.GetBuilder()
 	assert.False(t, r.FetchChanges(1, builder))
 }
 
 func TestFetchChangesStatusOnly(t *testing.T) {
-	r := CreateResponse()
+	r := CreateReqResponse()
 	r.WriteHeader(400)
 	builder := util.GetBuilder()
 	assert.True(t, r.FetchChanges(1, builder))
@@ -86,7 +86,7 @@ func TestFetchChangesStatusOnly(t *testing.T) {
 }
 
 func TestWriteHeaderTwice(t *testing.T) {
-	r := CreateResponse()
+	r := CreateReqResponse()
 	r.WriteHeader(400)
 	r.WriteHeader(503)
 	builder := util.GetBuilder()

--- a/internal/http/request.go
+++ b/internal/http/request.go
@@ -421,17 +421,3 @@ func ReuseRequest(r *Request) {
 	r.Reset()
 	reqPool.Put(r)
 }
-
-type Header struct {
-	http.Header
-}
-
-func newHeader() *Header {
-	return &Header{
-		Header: http.Header{},
-	}
-}
-
-func (h *Header) View() http.Header {
-	return h.Header
-}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -95,7 +95,7 @@ func findPlugin(name string) *pluginOpts {
 	return nil
 }
 
-func filter(conf RuleConf, w *inHTTP.Response, r pkgHTTP.Request) error {
+func filter(conf RuleConf, w *inHTTP.ReqResponse, r pkgHTTP.Request) error {
 	for _, c := range conf {
 		plugin := findPlugin(c.Name)
 		if plugin == nil {
@@ -115,7 +115,7 @@ func filter(conf RuleConf, w *inHTTP.Response, r pkgHTTP.Request) error {
 	return nil
 }
 
-func reportAction(id uint32, req *inHTTP.Request, resp *inHTTP.Response) *flatbuffers.Builder {
+func reportAction(id uint32, req *inHTTP.Request, resp *inHTTP.ReqResponse) *flatbuffers.Builder {
 	builder := util.GetBuilder()
 
 	if resp != nil && resp.FetchChanges(id, builder) {
@@ -138,8 +138,8 @@ func HTTPReqCall(buf []byte, conn net.Conn) (*flatbuffers.Builder, error) {
 	req.BindConn(conn)
 	defer inHTTP.ReuseRequest(req)
 
-	resp := inHTTP.CreateResponse()
-	defer inHTTP.ReuseResponse(resp)
+	resp := inHTTP.CreateReqResponse()
+	defer inHTTP.ReuseReqResponse(resp)
 
 	token := req.ConfToken()
 	conf, err := GetRuleConf(token)

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -319,14 +319,14 @@ func TestFilter(t *testing.T) {
 	out := builder.FinishedBytes()
 
 	req := inHTTP.CreateRequest(out)
-	resp := inHTTP.CreateResponse()
+	resp := inHTTP.CreateReqResponse()
 	filter(res, resp, req)
 
 	assert.Equal(t, "bar", resp.Header().Get("foo"))
 	assert.Equal(t, "", req.Header().Get("foo"))
 
 	req = inHTTP.CreateRequest(out)
-	resp = inHTTP.CreateResponse()
+	resp = inHTTP.CreateReqResponse()
 	prepareConfWithData(builder, barName, barConf, fooName, fooConf)
 	res, _ = GetRuleConf(2)
 	filter(res, resp, req)
@@ -369,7 +369,7 @@ func TestFilter_SetRespHeaderDoNotBreakReq(t *testing.T) {
 	out := builder.FinishedBytes()
 
 	req := inHTTP.CreateRequest(out)
-	resp := inHTTP.CreateResponse()
+	resp := inHTTP.CreateReqResponse()
 	filter(res, resp, req)
 
 	assert.Equal(t, "bar", req.Header().Get("foo"))
@@ -402,7 +402,7 @@ func TestFilter_SetRespHeader(t *testing.T) {
 	out := builder.FinishedBytes()
 
 	req := inHTTP.CreateRequest(out)
-	resp := inHTTP.CreateResponse()
+	resp := inHTTP.CreateReqResponse()
 	filter(res, resp, req)
 
 	assert.Equal(t, "baz", req.RespHeader().Get("foo"))


### PR DESCRIPTION
We will add `response.go` and `Response` interface  to support response phase