### PR TITLE
fix time.Since issue

### DIFF
--- a/cmd/go-runner/plugins/limit_req_test.go
+++ b/cmd/go-runner/plugins/limit_req_test.go
@@ -54,7 +54,7 @@ func TestLimitReq(t *testing.T) {
 	}
 	assert.Equal(t, 0, rejectN)
 	t.Logf("Start: %v, now: %v", start, time.Now())
-	assert.True(t, time.Now().Sub(start) >= 1*time.Second)
+	assert.True(t, time.Since(start) >= 1*time.Second)
 }
 
 func TestLimitReq_YouShouldNotPass(t *testing.T) {


### PR DESCRIPTION
Change `time.Now().Sub` to `time.Since`.

reference: [should use time.Since instead of time.Now().Sub (S1012)go-staticcheck](https://staticcheck.io/docs/checks#S1012)